### PR TITLE
Fixed null pointer. (gcc7 compilation errors)

### DIFF
--- a/src/libs/musicplayer/OpenALMusicPlayer.cpp
+++ b/src/libs/musicplayer/OpenALMusicPlayer.cpp
@@ -161,7 +161,7 @@ bool OpenALMusicPlayer::streamBuffer(ALuint buffer)
 {
 	char pcm[BUFFERSIZE];
 	int size = 0;
-	const char* error = '\0';
+	const char* error = nullptr;
 	
 	if (!stream->read(pcm, BUFFERSIZE, &size, &error)) {
 		GfError("OpenALMusicPlayer: Stream read error: %s\n", error);


### PR DESCRIPTION
I was having same error as given in the topic https://unix.stackexchange.com/questions/444874/problem-with-torcs-installation-error-with-openal

This pull  request should fix it